### PR TITLE
copy ceph config files to volume container

### DIFF
--- a/ansible-deployment/volume/tasks/main.yaml
+++ b/ansible-deployment/volume/tasks/main.yaml
@@ -36,6 +36,11 @@
      - name: add multipath.conf to /etc
        copy: src=multipath.conf dest=/etc mode=0644
 
+     - name: copy ceph.conf to cinder volume container
+       command: podman cp ceph.conf openstack-cinder-volume-podman-0:/etc/ceph
+
+     - name: copy ceph.client.esi.keyring to cinder volume container
+       command: podman cp ceph.client.esi.keyring openstack-cinder-volume-podman-0:/etc/ceph
+
      - name: restart cinder volume container
        command: podman container restart openstack-cinder-volume-podman-0
-


### PR DESCRIPTION
I didn't add ceph.conf and ceph.client.esi.keyring into this repo because I'm not sure if they contain credentials. But when we run ansible-playbooks, we need to add these files into ansible-deployment/volume/tasks.