### PR TITLE
Added cha3 and cha4 in OCT4

### DIFF
--- a/bm_inventory_oct.json
+++ b/bm_inventory_oct.json
@@ -333,6 +333,438 @@
                   }
                 }
             ]
+        },
+	{
+            "name": "oct4-cha3-1a",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.131",
+                "ipmi_terminal_port": 8036
+            },
+            "ports": [
+                {
+                    "address": "A8:99:69:A7:0A:01",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/33",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha3-1b",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.132",
+                "ipmi_terminal_port": 8037
+            },
+            "ports": [
+                {
+                    "address": "A8:99:69:A7:0A:EF",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/34",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha3-1c",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.133",
+                "ipmi_terminal_port": 8038
+            },
+            "ports": [
+                {
+                    "address": "A8:99:69:A7:0A:69",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/35",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha3-1d",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.134",
+                "ipmi_terminal_port": 8039
+            },
+            "ports": [
+                {
+                    "address": "A8:99:69:A7:10:A7",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/36",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha3-3a",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.135",
+                "ipmi_terminal_port": 8040
+            },
+            "ports": [
+                {
+                    "address": "A8:99:69:A7:0A:1B",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/37",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha3-3b",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.136",
+                "ipmi_terminal_port": 8041
+            },
+            "ports": [
+                {
+                    "address": "A8:99:69:A7:0C:5D",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/38",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha3-3c",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.137",
+                "ipmi_terminal_port": 8042
+            },
+            "ports": [
+                {
+                    "address": "A8:99:69:A7:0A:83",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/39",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha3-3d",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.138",
+                "ipmi_terminal_port": 8043
+            },
+            "ports": [
+                {
+                    "address": "A8:99:69:A7:12:15",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/40",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+	{
+            "name": "oct4-cha4-1a",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.141",
+                "ipmi_terminal_port": 8044
+            },
+            "ports": [
+                {
+                    "address": "D8:D0:90:DA:A1:71",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/41",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha4-1b",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.142",
+                "ipmi_terminal_port": 8045
+            },
+            "ports": [
+                {
+                    "address": "D8:D0:90:DA:A2:5F",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/42",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha4-1c",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.143",
+                "ipmi_terminal_port": 8046
+            },
+            "ports": [
+                {
+                    "address": "D8:D0:90:DA:A1:D9",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/43",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha4-1d",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.144",
+                "ipmi_terminal_port": 8047
+            },
+            "ports": [
+                {
+                    "address": "D8:D0:90:DA:A8:17",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/44",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha4-3a",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.145",
+                "ipmi_terminal_port": 8048
+            },
+            "ports": [
+                {
+                    "address": "D8:D0:90:DA:A1:8B",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/45",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha4-3b",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.146",
+                "ipmi_terminal_port": 8049
+            },
+            "ports": [
+                {
+                    "address": "D8:D0:90:DA:A3:CD",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/46",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha4-3c",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.147",
+                "ipmi_terminal_port": 8050
+            },
+            "ports": [
+                {
+                    "address": "D8:D0:90:DA:A1:F3",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/47",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "oct4-cha4-3d",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "baremetal",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "xxxxxxxx",
+                "ipmi_address": "10.2.4.148",
+                "ipmi_terminal_port": 8051
+            },
+            "ports": [
+                {
+                    "address": "D8:D0:90:DA:A9:85",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "switch1",
+                        "port_id": "tengigabitethernet 1/48",
+                        "switch_id": "4c:d9:8f:dc:e0:cb"
+                    }
+                }
+            ]
         }
     ]
 }

--- a/bm_inventory_oct.json
+++ b/bm_inventory_oct.json
@@ -337,7 +337,8 @@
 	{
             "name": "oct4-cha3-1a",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -364,7 +365,8 @@
         {
             "name": "oct4-cha3-1b",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -391,7 +393,8 @@
         {
             "name": "oct4-cha3-1c",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -418,7 +421,8 @@
         {
             "name": "oct4-cha3-1d",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -445,7 +449,8 @@
         {
             "name": "oct4-cha3-3a",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -472,7 +477,8 @@
         {
             "name": "oct4-cha3-3b",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -499,7 +505,8 @@
         {
             "name": "oct4-cha3-3c",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -526,7 +533,8 @@
         {
             "name": "oct4-cha3-3d",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -553,7 +561,8 @@
 	{
             "name": "oct4-cha4-1a",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -580,7 +589,8 @@
         {
             "name": "oct4-cha4-1b",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -607,7 +617,8 @@
         {
             "name": "oct4-cha4-1c",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -634,7 +645,8 @@
         {
             "name": "oct4-cha4-1d",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -661,7 +673,8 @@
         {
             "name": "oct4-cha4-3a",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -688,7 +701,8 @@
         {
             "name": "oct4-cha4-3b",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -715,7 +729,8 @@
         {
             "name": "oct4-cha4-3c",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",
@@ -742,7 +757,8 @@
         {
             "name": "oct4-cha4-3d",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+		"root_device":  {"size": ">= 50"}
             },
             "resource_class": "baremetal",
             "driver": "ipmi",


### PR DESCRIPTION
These are the initial imports for cha3 and cha4 in OCT4 (cha1 and cha2 were not added to the ESI pool). Root passwords have been obfuscated.