### PR TITLE
R4-PA-C21 Initial Manifest

### DIFF
--- a/bm_inventory_r4pac21.json
+++ b/bm_inventory_r4pac21.json
@@ -1,7 +1,7 @@
 {
     "nodes": [
       {
-        "name": "MOC-R4PAC21U37-S1A-OBM",
+        "name": "MOC-R4PAC21U37-S1A",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -37,7 +37,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U37-S1B-OBM",
+        "name": "MOC-R4PAC21U37-S1B",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -73,7 +73,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U37-S1C-OBM",
+        "name": "MOC-R4PAC21U37-S1C",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -109,7 +109,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U37-S1D-OBM",
+        "name": "MOC-R4PAC21U37-S1D",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -145,7 +145,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U37-S3A-OBM",
+        "name": "MOC-R4PAC21U37-S3A",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -181,7 +181,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U37-S3B-OBM",
+        "name": "MOC-R4PAC21U37-S3B",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -217,7 +217,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U37-S3C-OBM",
+        "name": "MOC-R4PAC21U37-S3C",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -253,7 +253,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U37-S3D-OBM",
+        "name": "MOC-R4PAC21U37-S3D",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -289,7 +289,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U35-S1A-OBM",
+        "name": "MOC-R4PAC21U35-S1A",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -325,7 +325,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U35-S1B-OBM",
+        "name": "MOC-R4PAC21U35-S1B",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -361,7 +361,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U35-S1C-OBM",
+        "name": "MOC-R4PAC21U35-S1C",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -397,7 +397,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U35-S1D-OBM",
+        "name": "MOC-R4PAC21U35-S1D",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -433,7 +433,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U35-S3A-OBM",
+        "name": "MOC-R4PAC21U35-S3A",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -469,7 +469,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U35-S3B-OBM",
+        "name": "MOC-R4PAC21U35-S3B",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -505,7 +505,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U35-S3C-OBM",
+        "name": "MOC-R4PAC21U35-S3C",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -541,7 +541,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U35-S3D-OBM",
+        "name": "MOC-R4PAC21U35-S3D",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -577,7 +577,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U31-S1A-OBM",
+        "name": "MOC-R4PAC21U31-S1A",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -613,7 +613,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U31-S1B-OBM",
+        "name": "MOC-R4PAC21U31-S1B",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -649,7 +649,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U31-S1C-OBM",
+        "name": "MOC-R4PAC21U31-S1C",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -685,7 +685,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U31-S3A-OBM",
+        "name": "MOC-R4PAC21U31-S3A",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -721,7 +721,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U31-S3B-OBM",
+        "name": "MOC-R4PAC21U31-S3B",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -757,7 +757,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U31-S3C-OBM",
+        "name": "MOC-R4PAC21U31-S3C",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -793,7 +793,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U31-S3D-OBM",
+        "name": "MOC-R4PAC21U31-S3D",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -829,7 +829,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U29-S3-OBM",
+        "name": "MOC-R4PAC21U29-S3",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -865,7 +865,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U27-S3-OBM",
+        "name": "MOC-R4PAC21U27-S3",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -901,7 +901,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U25-S1-OBM",
+        "name": "MOC-R4PAC21U25-S1",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -937,7 +937,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U23-S3-OBM",
+        "name": "MOC-R4PAC21U23-S3",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -973,7 +973,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U21-S1-OBM",
+        "name": "MOC-R4PAC21U21-S1",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1009,7 +1009,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U21-S3-OBM",
+        "name": "MOC-R4PAC21U21-S3",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1045,7 +1045,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U17-S1-OBM",
+        "name": "MOC-R4PAC21U17-S1",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1081,7 +1081,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U17-S3-OBM",
+        "name": "MOC-R4PAC21U17-S3",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1117,7 +1117,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U15-S1-OBM",
+        "name": "MOC-R4PAC21U15-S1",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1153,7 +1153,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U15-S3-OBM",
+        "name": "MOC-R4PAC21U15-S3",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1189,7 +1189,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U13-S3-OBM",
+        "name": "MOC-R4PAC21U13-S3",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1225,7 +1225,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U11-S1-OBM",
+        "name": "MOC-R4PAC21U11-S1",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1261,7 +1261,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U11-S3-OBM",
+        "name": "MOC-R4PAC21U11-S3",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1297,7 +1297,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U09-S1-OBM",
+        "name": "MOC-R4PAC21U09-S1",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1333,7 +1333,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U09-S3-OBM",
+        "name": "MOC-R4PAC21U09-S3",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1369,7 +1369,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U03-S1-OBM",
+        "name": "MOC-R4PAC21U03-S1",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },
@@ -1405,7 +1405,7 @@
         ]
       },
       {
-        "name": "MOC-R4PAC21U03-S3-OBM",
+        "name": "MOC-R4PAC21U03-S3",
         "properties": {
           "capabilities": "iscsi_boot:True"
         },

--- a/bm_inventory_r4pac21.json
+++ b/bm_inventory_r4pac21.json
@@ -849,7 +849,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/8/2",
+              "port_id": "twentyfivegige 1/8/2",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -858,7 +858,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/8/2",
+              "port_id": "twentyfivegige 1/8/2",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -885,7 +885,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/7/4",
+              "port_id": "twentyfivegige 1/7/4",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -894,7 +894,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/7/4",
+              "port_id": "twentyfivegige 1/7/4",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -921,7 +921,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/7/1",
+              "port_id": "twentyfivegige 1/7/1",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -930,7 +930,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/7/1",
+              "port_id": "twentyfivegige 1/7/1",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -957,7 +957,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/6/4",
+              "port_id": "twentyfivegige 1/6/4",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -966,7 +966,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/6/4",
+              "port_id": "twentyfivegige 1/6/4",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -993,7 +993,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/6/1",
+              "port_id": "twentyfivegige 1/6/1",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1002,7 +1002,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/6/1",
+              "port_id": "twentyfivegige 1/6/1",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1029,7 +1029,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/6/2",
+              "port_id": "twentyfivegige 1/6/2",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1038,7 +1038,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/6/2",
+              "port_id": "twentyfivegige 1/6/2",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1065,7 +1065,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/5/1",
+              "port_id": "twentyfivegige 1/5/1",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1074,7 +1074,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/5/1",
+              "port_id": "twentyfivegige 1/5/1",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1101,7 +1101,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/5/2",
+              "port_id": "twentyfivegige 1/5/2",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1110,7 +1110,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/5/2",
+              "port_id": "twentyfivegige 1/5/2",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1137,7 +1137,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/4/3",
+              "port_id": "twentyfivegige 1/4/3",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1146,7 +1146,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/4/3",
+              "port_id": "twentyfivegige 1/4/3",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1173,7 +1173,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/4/4",
+              "port_id": "twentyfivegige 1/4/4",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1182,7 +1182,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/4/4",
+              "port_id": "twentyfivegige 1/4/4",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1209,7 +1209,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/4/2",
+              "port_id": "twentyfivegige 1/4/2",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1218,7 +1218,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/4/2",
+              "port_id": "twentyfivegige 1/4/2",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1245,7 +1245,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/3/3",
+              "port_id": "twentyfivegige 1/3/3",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1254,7 +1254,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/3/3",
+              "port_id": "twentyfivegige 1/3/3",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1281,7 +1281,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/3/4",
+              "port_id": "twentyfivegige 1/3/4",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1290,7 +1290,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/3/4",
+              "port_id": "twentyfivegige 1/3/4",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1317,7 +1317,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/3/1",
+              "port_id": "twentyfivegige 1/3/1",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1326,7 +1326,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/3/1",
+              "port_id": "twentyfivegige 1/3/1",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1353,7 +1353,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/3/2",
+              "port_id": "twentyfivegige 1/3/2",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1362,7 +1362,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/3/2",
+              "port_id": "twentyfivegige 1/3/2",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1389,7 +1389,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/1/3",
+              "port_id": "twentyfivegige 1/1/3",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1398,7 +1398,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/1/3",
+              "port_id": "twentyfivegige 1/1/3",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }
@@ -1425,7 +1425,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
-              "port_id": "twentyFiveGigE 1/1/4",
+              "port_id": "twentyfivegige 1/1/4",
               "switch_id": "d8:9e:f3:a4:46:a2"
             }
           },
@@ -1434,7 +1434,7 @@
             "physical_network": "datacentre",
             "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-B",
-              "port_id": "twentyFiveGigE 1/1/4",
+              "port_id": "twentyfivegige 1/1/4",
               "switch_id": "0c:29:ef:a0:8d:a2"
             }
           }

--- a/bm_inventory_r4pac21.json
+++ b/bm_inventory_r4pac21.json
@@ -1,0 +1,1445 @@
+{
+    "nodes": [
+      {
+        "name": "MOC-R4PAC21U37-S1A-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.191",
+          "ipmi_terminal_port": 10191
+        },
+        "ports": [
+          {
+            "address": "40:5C:FD:67:E9:41",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/15/1",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "40:5C:FD:67:E9:44",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/15/1",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U37-S1B-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.192",
+          "ipmi_terminal_port": 10192
+        },
+        "ports": [
+          {
+            "address": "40:5C:FD:67:EA:2F",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/15/2",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "40:5C:FD:67:EA:32",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/15/2",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U37-S1C-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.193",
+          "ipmi_terminal_port": 10193
+        },
+        "ports": [
+          {
+            "address": "40:5C:FD:67:E9:A9",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/15/3",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "40:5C:FD:67:E9:AC",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/15/3",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U37-S1D-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.194",
+          "ipmi_terminal_port": 10194
+        },
+        "ports": [
+          {
+            "address": "40:5C:FD:67:EF:E7",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/15/4",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "40:5C:FD:67:EF:EA",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/15/4",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U37-S3A-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.195",
+          "ipmi_terminal_port": 10195
+        },
+        "ports": [
+          {
+            "address": "40:5C:FD:67:E9:5B",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/16/1",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "40:5C:FD:67:E9:5E",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/16/1",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U37-S3B-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.196",
+          "ipmi_terminal_port": 10196
+        },
+        "ports": [
+          {
+            "address": "40:5C:FD:67:EB:9D",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/16/2",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "40:5C:FD:67:EB:A0",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/16/2",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U37-S3C-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.197",
+          "ipmi_terminal_port": 10197
+        },
+        "ports": [
+          {
+            "address": "40:5C:FD:67:E9:C3",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/16/3",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "40:5C:FD:67:E9:C6",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/16/3",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U37-S3D-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.198",
+          "ipmi_terminal_port": 10198
+        },
+        "ports": [
+          {
+            "address": "40:5C:FD:67:F1:55",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/16/4",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "40:5C:FD:67:F1:58",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/16/4",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U35-S1A-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.181",
+          "ipmi_terminal_port": 10181
+        },
+        "ports": [
+          {
+            "address": "A8:99:69:84:46:41",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/13/1",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "A8:99:69:84:46:44",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/13/1",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U35-S1B-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.182",
+          "ipmi_terminal_port": 10182
+        },
+        "ports": [
+          {
+            "address": "A8:99:69:84:47:2F",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/13/2",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "A8:99:69:84:47:32",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/13/2",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U35-S1C-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.183",
+          "ipmi_terminal_port": 10183
+        },
+        "ports": [
+          {
+            "address": "A8:99:69:84:46:A9",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/13/3",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "A8:99:69:84:46:AC",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/13/3",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U35-S1D-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.184",
+          "ipmi_terminal_port": 10184
+        },
+        "ports": [
+          {
+            "address": "A8:99:69:84:4C:E7",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/13/4",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "A8:99:69:84:4C:EA",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/13/4",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U35-S3A-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.185",
+          "ipmi_terminal_port": 10185
+        },
+        "ports": [
+          {
+            "address": "A8:99:69:84:46:5B",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/14/1",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "A8:99:69:84:46:5E",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/14/1",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U35-S3B-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.186",
+          "ipmi_terminal_port": 10186
+        },
+        "ports": [
+          {
+            "address": "A8:99:69:84:48:9D",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/14/2",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "A8:99:69:84:48:A0",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/14/2",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U35-S3C-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.187",
+          "ipmi_terminal_port": 10187
+        },
+        "ports": [
+          {
+            "address": "A8:99:69:84:46:C3",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/14/3",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "A8:99:69:84:46:C6",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/14/3",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U35-S3D-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.188",
+          "ipmi_terminal_port": 10188
+        },
+        "ports": [
+          {
+            "address": "A8:99:69:84:4E:55",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/14/4",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "A8:99:69:84:4E:58",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/14/4",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U31-S1A-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.161",
+          "ipmi_terminal_port": 10161
+        },
+        "ports": [
+          {
+            "address": "E0:D8:48:E3:93:41",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/9/1",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "E0:D8:48:E3:93:44",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/9/1",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U31-S1B-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.162",
+          "ipmi_terminal_port": 10162
+        },
+        "ports": [
+          {
+            "address": "E0:D8:48:E3:94:2F",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/9/2",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "E0:D8:48:E3:94:32",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/9/2",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U31-S1C-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.163",
+          "ipmi_terminal_port": 10163
+        },
+        "ports": [
+          {
+            "address": "E0:D8:48:E3:93:A9",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/9/3",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "E0:D8:48:E3:93:AC",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/9/3",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U31-S3A-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.165",
+          "ipmi_terminal_port": 10165
+        },
+        "ports": [
+          {
+            "address": "E0:D8:48:E3:93:5B",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/10/1",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "E0:D8:48:E3:93:5E",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/10/1",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U31-S3B-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.166",
+          "ipmi_terminal_port": 10166
+        },
+        "ports": [
+          {
+            "address": "E0:D8:48:E3:95:9D",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/10/2",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "E0:D8:48:E3:95:A0",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/10/2",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U31-S3C-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.167",
+          "ipmi_terminal_port": 10167
+        },
+        "ports": [
+          {
+            "address": "E0:D8:48:E3:93:C3",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/10/3",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "E0:D8:48:E3:93:C6",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/10/3",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U31-S3D-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.168",
+          "ipmi_terminal_port": 10168
+        },
+        "ports": [
+          {
+            "address": "E0:D8:48:E3:9B:55",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "tengigabitethernet 1/10/4",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "E0:D8:48:E3:9B:58",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "tengigabitethernet 1/10/4",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U29-S3-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.152",
+          "ipmi_terminal_port": 10152
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:7b:e4:e0",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/8/2",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:7b:e4:e1",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/8/2",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U27-S3-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.142",
+          "ipmi_terminal_port": 10142
+        },
+        "ports": [
+          {
+            "address": "b8:ce:f6:0a:f7:cc",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/7/4",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "b8:ce:f6:0a:f7:cd",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/7/4",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U25-S1-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.131",
+          "ipmi_terminal_port": 10131
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:7b:e4:f0",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/7/1",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:7b:e4:f1",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/7/1",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U23-S3-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.122",
+          "ipmi_terminal_port": 10122
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:7b:e4:a0",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/6/4",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:7b:e4:a1",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/6/4",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U21-S1-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.111",
+          "ipmi_terminal_port": 10111
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:95:c4:ac",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/6/1",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:95:c4:ad",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/6/1",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U21-S3-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.112",
+          "ipmi_terminal_port": 10112
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:7b:e4:08",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/6/2",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:7b:e4:09",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/6/2",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U17-S1-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.91",
+          "ipmi_terminal_port": 10091
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:7b:e4:c0",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/5/1",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:7b:e4:c1",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/5/1",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U17-S3-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.92",
+          "ipmi_terminal_port": 10092
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:7b:e4:7c",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/5/2",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:7b:e4:7d",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/5/2",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U15-S1-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.81",
+          "ipmi_terminal_port": 10081
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:51:3d:64",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/4/3",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:51:3d:65",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/4/3",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U15-S3-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.82",
+          "ipmi_terminal_port": 10082
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:7b:e4:b4",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/4/4",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:7b:e4:b5",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/4/4",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U13-S3-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.72",
+          "ipmi_terminal_port": 10072
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:7c:04:64",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/4/2",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:7c:04:65",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/4/2",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U11-S1-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.61",
+          "ipmi_terminal_port": 10061
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:51:3d:c4",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/3/3",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:51:3d:c5",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/3/3",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U11-S3-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.62",
+          "ipmi_terminal_port": 10062
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:aa:8f:3a",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/3/4",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:aa:8f:3b",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/3/4",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U09-S1-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.51",
+          "ipmi_terminal_port": 10051
+        },
+        "ports": [
+          {
+            "address": "0c:42:a1:95:c5:24",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/3/1",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "0c:42:a1:95:c5:25",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/3/1",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U09-S3-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.52",
+          "ipmi_terminal_port": 10052
+        },
+        "ports": [
+          {
+            "address": "b8:59:9f:1a:d9:86",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/3/2",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "b8:59:9f:1a:d9:87",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/3/2",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U03-S1-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.21",
+          "ipmi_terminal_port": 10021
+        },
+        "ports": [
+          {
+            "address": "98:03:9b:ad:65:d4",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/1/3",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "98:03:9b:ad:65:d5",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/1/3",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      },
+      {
+        "name": "MOC-R4PAC21U03-S3-OBM",
+        "properties": {
+          "capabilities": "iscsi_boot:True"
+        },
+        "resource_class": "baremetal",
+        "driver": "ipmi",
+        "driver_info": {
+          "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+          "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+          "ipmi_username": "root",
+          "ipmi_password": "",
+          "ipmi_address": "10.2.10.22",
+          "ipmi_terminal_port": 10022
+        },
+        "ports": [
+          {
+            "address": "b8:59:9f:3b:4c:f2",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "twentyFiveGigE 1/1/4",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+            }
+          },
+          {
+            "address": "b8:59:9f:3b:4c:f3",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-B",
+              "port_id": "twentyFiveGigE 1/1/4",
+              "switch_id": "0c:29:ef:a0:8d:a2"
+            }
+          }
+        ]
+      }
+    ]
+  }
+  


### PR DESCRIPTION
This PR adds the bare-metal manifest for all the ready nodes in R4-PA-C21. There are several nodes in that rack that are missing from this manifest because there is some missing information or broken hardware, which will be added to the same file in a future PR.

Some notes:
* iDrac admin password is redacted
* All nodes have been firmware updated to the latest version, configured to pxe boot, and ipmi over lan enabled. BIOS is the boot mode.
* The IPMI port comes from the idrac IP. For example, is the ip of the node is `10.2.10.161`, the port is `10161`. Hope this works!
* It's possible some of the switchports are swapped. ie. the first port actually goes to the 2nd switch etc. If this is the case I will swap the connections in person, so the manifest will stay the same.

Each node is connected to 2 switches at the top of rack and all esi vlans have been trunked to those switches already.

This hardware is a mix of FC830s (quad socket), and FC430s (dual socket). All have 2016 or above CPU models.