### PR TITLE
Updated neutron policy file to allow tenants to modify port binding host_id

### DIFF
--- a/policy_files/policy.yaml
+++ b/policy_files/policy.yaml
@@ -186,7 +186,7 @@
 "update_port:fixed_ips:ip_address": "rule:context_is_advsvc or rule:network_owner or role:admin and system_scope:all or role:admin and project_id:%(project_id)s"
 "update_port:fixed_ips:subnet_id": "rule:context_is_advsvc or rule:network_owner or role:admin and system_scope:all or role:admin and project_id:%(project_id)s or rule:shared"
 "update_port:port_security_enabled": "rule:context_is_advsvc or rule:network_owner or role:admin and system_scope:all or role:admin and project_id:%(project_id)s"
-"update_port:binding:host_id": "role:admin and system_scope:all"
+"update_port:binding:host_id": "(role:admin and system_scope:all) or (role:member and project_id:%(project_id)s)"
 "update_port:binding:profile": "role:admin and system_scope:all"
 "update_port:binding:vnic_type": "(role:admin and system_scope:all) or (role:member and project_id:%(project_id)s) or rule:context_is_advsvc"
 "update_port:allowed_address_pairs": "role:admin and system_scope:all or role:admin and project_id:%(project_id)s or rule:network_owner"


### PR DESCRIPTION
This change is needed for tenants to use tools such as Metalsmith.