### PR TITLE
Install network-runner so that it includes all the network providers

### DIFF
--- a/custom-dockerfiles/neutron-server/Dockerfile
+++ b/custom-dockerfiles/neutron-server/Dockerfile
@@ -8,7 +8,7 @@ RUN sed -i 's/$stream/8-stream/g' /etc/yum.repos.d/CentOS-* && \
 	git clone https://github.com/CCI-MOC/network-runner && \
 	cd network-runner && \
         git checkout esi_network_runner && \
-	\cp -r etc/ansible/roles/network-runner/providers/nos /etc/ansible/roles/network-runner/providers/. && \
+	python3 setup.py install && \
 	yum clean all
 
 RUN cd /tmp && \


### PR DESCRIPTION
I ran into the issue on the new cluster because the neutron image did not include the dellemc os9 provider. Manually copying the os9 driver didn't fix the issue because network_runners' old version of inventory.py does not dynamically load the network providers (so in the logs it showed up as "dellemcos9.os9 is an invalid choice").

Closes: https://github.com/CCI-MOC/esi/issues/490