### PR TITLE
Updated host for switch1

### DIFF
--- a/ansible-deployment/switch/tasks/switches.j2
+++ b/ansible-deployment/switch/tasks/switches.j2
@@ -3,7 +3,7 @@ coordination_uri=redis://:{{ masterauth_value.stdout }}@{{ master_ip }}:6379/
 [ansible:switch1]
 ansible_connection=ansible.netcommon.network_cli
 ansible_network_os=dellemc.os9.os9
-ansible_host={{ ansible_switch_host }}
+ansible_host=10.2.4.90
 ansible_user=admin
 ansible_ssh_pass={{ ansible_switch_ssh_password }}
 ansible_become_password={{ ansible_switch_ssh_password }}


### PR DESCRIPTION
As discussed on Slack, this is the change that happened during maintenance yesterday for `switch1`.