### PR TITLE
Adding NVMe Nodes

### DIFF
--- a/nodes/bm_inventory_r4pac08.json
+++ b/nodes/bm_inventory_r4pac08.json
@@ -1083,9 +1083,10 @@
         {
             "name": "MOC-R4PAC08U29-S1",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+                "root_device": "{\"wwn\": \"0x5002538a4910ece0\"}"
             },
-            "resource_class": "baremetal",
+            "resource_class": "fc830-nvme",
             "driver": "ipmi",
             "driver_info": {
                 "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
@@ -1111,6 +1112,24 @@
                     "local_link_connection": {
                         "switch_info": "MOC-R4PAC08-SW-TORS-B",
                         "port_id": "twentyfivegige 1/7/3",
+                        "switch_id": "4c:76:25:e7:e3:42"
+                    }
+                },
+                {
+                    "address": "f4:52:14:01:b9:e1",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "MOC-R4PAC08-SW-TORS-A",
+                        "port_id": "fortygige 1/17/1",
+                        "switch_id": "d8:9e:f3:ae:e5:a2"
+                    }
+                },
+                {
+                    "address": "f4:52:14:01:b9:e2",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "MOC-R4PAC08-SW-TORS-B",
+                        "port_id": "fortygige 1/17/1",
                         "switch_id": "4c:76:25:e7:e3:42"
                     }
                 }

--- a/nodes/bm_inventory_r4pac08.json
+++ b/nodes/bm_inventory_r4pac08.json
@@ -1084,7 +1084,9 @@
             "name": "MOC-R4PAC08U29-S1",
             "properties": {
                 "capabilities": "iscsi_boot:True",
-                "root_device": "{\"wwn\": \"0x5002538a4910ece0\"}"
+                "root_device": {
+                    "wwn": "0x5002538a4910ece0"
+                }
             },
             "resource_class": "fc830-nvme",
             "driver": "ipmi",

--- a/nodes/bm_inventory_r4pac08.json
+++ b/nodes/bm_inventory_r4pac08.json
@@ -1118,6 +1118,7 @@
                 {
                     "address": "f4:52:14:01:b9:e1",
                     "physical_network": "datacentre",
+                    "pxe_enabled": "False",
                     "local_link_connection": {
                         "switch_info": "MOC-R4PAC08-SW-TORS-A",
                         "port_id": "fortygige 1/17/1",
@@ -1127,6 +1128,7 @@
                 {
                     "address": "f4:52:14:01:b9:e2",
                     "physical_network": "datacentre",
+                    "pxe_enabled": "False",
                     "local_link_connection": {
                         "switch_info": "MOC-R4PAC08-SW-TORS-B",
                         "port_id": "fortygige 1/17/1",

--- a/nodes/bm_inventory_r4pac10.json
+++ b/nodes/bm_inventory_r4pac10.json
@@ -1012,7 +1012,9 @@
             "name": "MOC-R4PAC10U29-S1",
             "properties": {
                 "capabilities": "iscsi_boot:True",
-                "root_device": "{\"wwn\": \"0x5002538a983785a0\"}"
+                "root_device": {
+                    "wwn": "0x5002538a983785a0"
+                }
             },
             "resource_class": "fc830-nvme",
             "driver": "ipmi",

--- a/nodes/bm_inventory_r4pac10.json
+++ b/nodes/bm_inventory_r4pac10.json
@@ -1011,9 +1011,10 @@
         {
             "name": "MOC-R4PAC10U29-S1",
             "properties": {
-                "capabilities": "iscsi_boot:True"
+                "capabilities": "iscsi_boot:True",
+                "root_device": "{\"wwn\": \"0x5002538a983785a0\"}"
             },
-            "resource_class": "baremetal",
+            "resource_class": "fc830-nvme",
             "driver": "ipmi",
             "driver_info": {
                 "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
@@ -1039,6 +1040,24 @@
                     "local_link_connection": {
                         "switch_info": "MOC-R4PAC10-SW-TORS-B",
                         "port_id": "twentyfivegige 1/7/3",
+                        "switch_id": "0c:29:ef:ce:8b:a2"
+                    }
+                },
+                {
+                    "address": "00:02:c9:a0:e6:e0",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "MOC-R4PAC10-SW-TORS-A",
+                        "port_id": "fortygige 1/17/1",
+                        "switch_id": "3c:2c:30:37:ee:02"
+                    }
+                },
+                {
+                    "address": "00:02:c9:a0:e6:e1",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "MOC-R4PAC10-SW-TORS-B",
+                        "port_id": "fortygige 1/17/1",
                         "switch_id": "0c:29:ef:ce:8b:a2"
                     }
                 }

--- a/nodes/bm_inventory_r4pac10.json
+++ b/nodes/bm_inventory_r4pac10.json
@@ -1046,6 +1046,7 @@
                 {
                     "address": "00:02:c9:a0:e6:e0",
                     "physical_network": "datacentre",
+                    "pxe_enabled": "False",
                     "local_link_connection": {
                         "switch_info": "MOC-R4PAC10-SW-TORS-A",
                         "port_id": "fortygige 1/17/1",
@@ -1055,6 +1056,7 @@
                 {
                     "address": "00:02:c9:a0:e6:e1",
                     "physical_network": "datacentre",
+                    "pxe_enabled": "False",
                     "local_link_connection": {
                         "switch_info": "MOC-R4PAC10-SW-TORS-B",
                         "port_id": "fortygige 1/17/1",

--- a/nodes/bm_inventory_r4pac21.json
+++ b/nodes/bm_inventory_r4pac21.json
@@ -1082,6 +1082,7 @@
         {
           "address": "00:02:c9:a1:07:80",
           "physical_network": "datacentre",
+          "pxe_enabled": "False",
           "local_link_connection": {
               "switch_info": "MOC-R4PAC21-SW-TORS-A",
               "port_id": "fortygige 1/17/1",
@@ -1091,6 +1092,7 @@
         {
             "address": "00:02:c9:a1:07:81",
             "physical_network": "datacentre",
+            "pxe_enabled": "False",
             "local_link_connection": {
                 "switch_info": "MOC-R4PAC21-SW-TORS-B",
                 "port_id": "fortygige 1/17/1",

--- a/nodes/bm_inventory_r4pac21.json
+++ b/nodes/bm_inventory_r4pac21.json
@@ -1047,9 +1047,10 @@
     {
       "name": "MOC-R4PAC21U29-S1",
       "properties": {
-        "capabilities": "iscsi_boot:True"
+        "capabilities": "iscsi_boot:True",
+        "root_device": "{\"wwn\": \"0x5002538a07289a80\"}"
       },
-      "resource_class": "baremetal",
+      "resource_class": "fc830-nvme",
       "driver": "ipmi",
       "driver_info": {
         "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
@@ -1077,6 +1078,24 @@
             "port_id": "twentyfivegige 1/8/1",
             "switch_id": "0c:29:ef:a0:8d:a2"
           }
+        },
+        {
+          "address": "00:02:c9:a1:07:80",
+          "physical_network": "datacentre",
+          "local_link_connection": {
+              "switch_info": "MOC-R4PAC21-SW-TORS-A",
+              "port_id": "fortygige 1/17/1",
+              "switch_id": "d8:9e:f3:a4:46:a2"
+          }
+        },
+        {
+            "address": "00:02:c9:a1:07:81",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+                "switch_info": "MOC-R4PAC21-SW-TORS-B",
+                "port_id": "fortygige 1/17/1",
+                "switch_id": "0c:29:ef:a0:8d:a2"
+            }
         }
       ]
     },

--- a/nodes/bm_inventory_r4pac21.json
+++ b/nodes/bm_inventory_r4pac21.json
@@ -1048,7 +1048,9 @@
       "name": "MOC-R4PAC21U29-S1",
       "properties": {
         "capabilities": "iscsi_boot:True",
-        "root_device": "{\"wwn\": \"0x5002538a07289a80\"}"
+        "root_device": {
+          "wwn": "0x5002538a07289a80"
+        }
       },
       "resource_class": "fc830-nvme",
       "driver": "ipmi",

--- a/nodes/bm_inventory_r4pac22.json
+++ b/nodes/bm_inventory_r4pac22.json
@@ -830,6 +830,7 @@
         {
           "address": "00:02:c9:38:d2:b0",
           "physical_network": "datacentre",
+          "pxe_enabled": "False",
           "local_link_connection": {
               "switch_info": "MOC-R4PAC22-SW-TORS-A",
               "port_id": "fortygige 1/17/1",
@@ -839,6 +840,7 @@
         {
             "address": "00:02:c9:38:d2:b1",
             "physical_network": "datacentre",
+            "pxe_enabled": "False",
             "local_link_connection": {
                 "switch_info": "MOC-R4PAC22-SW-TORS-B",
                 "port_id": "fortygige 1/17/1",

--- a/nodes/bm_inventory_r4pac22.json
+++ b/nodes/bm_inventory_r4pac22.json
@@ -795,9 +795,10 @@
     {
       "name": "MOC-R4PAC22U29-S1",
       "properties": {
-        "capabilities": "iscsi_boot:True"
+        "capabilities": "iscsi_boot:True",
+        "root_device": "{\"wwn\": \"0x5002538a986b9be0\"}"
       },
-      "resource_class": "baremetal",
+      "resource_class": "fc830-nvme",
       "driver": "ipmi",
       "driver_info": {
         "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
@@ -825,6 +826,24 @@
             "port_id": "twentyfivegige 1/7/3",
             "switch_id": "d8:9e:f3:a2:18:22"
           }
+        },
+        {
+          "address": "00:02:c9:38:d2:b0",
+          "physical_network": "datacentre",
+          "local_link_connection": {
+              "switch_info": "MOC-R4PAC22-SW-TORS-A",
+              "port_id": "fortygige 1/17/1",
+              "switch_id": "34:17:eb:37:e7:82"
+          }
+        },
+        {
+            "address": "00:02:c9:38:d2:b1",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+                "switch_info": "MOC-R4PAC22-SW-TORS-B",
+                "port_id": "fortygige 1/17/1",
+                "switch_id": "d8:9e:f3:a2:18:22"
+            }
         }
       ]
     },

--- a/nodes/bm_inventory_r4pac22.json
+++ b/nodes/bm_inventory_r4pac22.json
@@ -796,7 +796,9 @@
       "name": "MOC-R4PAC22U29-S1",
       "properties": {
         "capabilities": "iscsi_boot:True",
-        "root_device": "{\"wwn\": \"0x5002538a986b9be0\"}"
+        "root_device": {
+          "wwn": "0x5002538a986b9be0"
+        }
       },
       "resource_class": "fc830-nvme",
       "driver": "ipmi",

--- a/nodes/bm_inventory_r4pac24.json
+++ b/nodes/bm_inventory_r4pac24.json
@@ -1011,9 +1011,10 @@
     {
       "name": "MOC-R4PAC24U29-S1",
       "properties": {
-        "capabilities": "iscsi_boot:True"
+        "capabilities": "iscsi_boot:True",
+        "root_device": "{\"wwn\": \"0x5002538a4897cc70\"}"
       },
-      "resource_class": "baremetal",
+      "resource_class": "fc830-nvme",
       "driver": "ipmi",
       "driver_info": {
         "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
@@ -1041,6 +1042,24 @@
             "port_id": "twentyfivegige 1/7/3",
             "switch_id": "0c:29:ef:bd:a8:a2"
           }
+        },
+        {
+          "address": "00:02:c9:a0:f6:40",
+          "physical_network": "datacentre",
+          "local_link_connection": {
+              "switch_info": "MOC-R4PAC24-SW-TORS-A",
+              "port_id": "fortygige 1/17/1",
+              "switch_id": "54:bf:64:ed:d7:c3"
+          }
+        },
+        {
+            "address": "00:02:c9:a0:f6:41",
+            "physical_network": "datacentre",
+            "local_link_connection": {
+                "switch_info": "MOC-R4PAC24-SW-TORS-B",
+                "port_id": "fortygige 1/17/1",
+                "switch_id": "0c:29:ef:bd:a8:a2"
+            }
         }
       ]
     },

--- a/nodes/bm_inventory_r4pac24.json
+++ b/nodes/bm_inventory_r4pac24.json
@@ -1012,7 +1012,9 @@
       "name": "MOC-R4PAC24U29-S1",
       "properties": {
         "capabilities": "iscsi_boot:True",
-        "root_device": "{\"wwn\": \"0x5002538a4897cc70\"}"
+        "root_device": {
+          "wwn": "0x5002538a4897cc70"
+        }
       },
       "resource_class": "fc830-nvme",
       "driver": "ipmi",

--- a/nodes/bm_inventory_r4pac24.json
+++ b/nodes/bm_inventory_r4pac24.json
@@ -1046,6 +1046,7 @@
         {
           "address": "00:02:c9:a0:f6:40",
           "physical_network": "datacentre",
+          "pxe_enabled": "False",
           "local_link_connection": {
               "switch_info": "MOC-R4PAC24-SW-TORS-A",
               "port_id": "fortygige 1/17/1",
@@ -1055,6 +1056,7 @@
         {
             "address": "00:02:c9:a0:f6:41",
             "physical_network": "datacentre",
+            "pxe_enabled": "False",
             "local_link_connection": {
                 "switch_info": "MOC-R4PAC24-SW-TORS-B",
                 "port_id": "fortygige 1/17/1",


### PR DESCRIPTION
This PR changes the relevant manifest properties for the nvme nodes (`U29-S1`) in each rack (These nodes are already in ESI). This includes

* Adding root disk wwn property since it otherwise defaults to boot off of the nvme drives
* Setting resource class to `fc830-nvme`
* Adding 2x interfaces for the 2x 40G nics on each node

The WWN is the only property I manually applied already, everything else still needs to be applied