### PR TITLE
Add configuration for GPU inspection

### DIFF
--- a/ansible-deployment/ironic_config/tasks/accelerators.yaml
+++ b/ansible-deployment/ironic_config/tasks/accelerators.yaml
@@ -1,0 +1,13 @@
+pci_devices:
+  - vendor_id: "10de"
+    device_id: "1eb8"
+    type: GPU
+    device_info: NVIDIA Corporation Tesla T4
+  - vendor_id: "10de"
+    device_id: "1df6"
+    type: GPU
+    device_info: NVIDIA Corporation GV100GL
+  - vendor_id: "10de"
+    device_id: "20b0"
+    type: GPU
+    device_info: NVIDIA Corporation GA100

--- a/ansible-deployment/ironic_config/tasks/main.yaml
+++ b/ansible-deployment/ironic_config/tasks/main.yaml
@@ -20,5 +20,24 @@
          path: /var/lib/config-data/puppet-generated/ironic/etc/ironic/ironic.conf
          insertafter: ^# *socat_address *=.*
          line: socat_address = {{ public_ip }}
-     - name: restart ironic container
-       command: podman container restart ironic_conductor
+     - name: Add extra kernel params for inspection
+       lineinfile:
+         path: /var/lib/config-data/puppet-generated/ironic/etc/ironic/ironic.conf
+         insertafter: ^# *extra_kernel_params *=.*
+         line: extra_kernel_params = ipa-inspection-collectors=default,pci-devices
+     - name: Update inspection processing hooks
+       lineinfile:
+         path: /var/lib/config-data/puppet-generated/ironic_inspector/etc/ironic-inspector/inspector.conf
+         insertafter: ^# *processing_hooks *=.*
+         line: processing_hooks=$default_processing_hooks,extra_hardware,lldp_basic,local_link_connection,physnet_cidr_map,accelerators
+     - name: Add accelerators section to inspection
+       blockinfile:
+         path: /var/lib/config-data/puppet-generated/ironic_inspector/etc/ironic-inspector/inspector.conf
+         backup: yes
+         block: |
+          [accelerators]
+          known_devices=/etc/ironic-inspector/accelerators.yaml
+     - name: Copy custom accelerators.yaml
+       copy: src=accelerators.yaml dest=/var/lib/config-data/puppet-generated/ironic_inspector/etc/ironic-inspector mode=0644
+    - name: restart ironic containers
+       command: podman container restart ironic_conductor ironic_inspector


### PR DESCRIPTION
These files and configurations are necessary for Ironic introspection to collect node data relevant for GPUs