### PR TITLE
Adding 2 new research nodes

### DIFF
--- a/ansible-deployment/switch/tasks/switches.j2
+++ b/ansible-deployment/switch/tasks/switches.j2
@@ -163,6 +163,19 @@ mac=4c:76:25:e7:e3:42
 manage_vlans=True
 ansible_connection=local
 stp_edge=True
+[ansible:MOC-R4PAC04-SW-TORS]
+ansible_connection=ansible.netcommon.network_cli
+ansible_network_os=dellemc.os9.os9
+ansible_host=10.2.16.1
+ansible_user=admin
+ansible_ssh_pass={{ ansible_sw_moc_ssh_password }}
+ansible_become_password={{ ansible_sw_moc_ssh_password }}
+ansible_become=yes
+ansible_become_method=enable
+mac=3c:2c:30:44:09:02
+manage_vlans=True
+ansible_connection=local
+stp_edge=True
 [ansible:OCT4-SW-ESIDEV]
 ansible_connection=ansible.netcommon.network_cli
 ansible_network_os=dellemc.os9.os9

--- a/nodes/bm_inventory_r4pac04.json
+++ b/nodes/bm_inventory_r4pac04.json
@@ -1,0 +1,76 @@
+{
+    "nodes": [
+        {
+            "name": "MOC-R4PAC04U33",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "whitebox-flax-1",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "",
+                "ipmi_address": "10.2.16.170",
+                "ipmi_terminal_port": 16170
+            },
+            "ports": [
+                {
+                    "address": "50:7C:6F:54:A9:7A",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "MOC-R4PAC04-SW-TORS",
+                        "port_id": "twentyfivegige 1/35",
+                        "switch_id": "3c:2c:30:44:09:02"
+                    }
+                },
+                {
+                    "address": "50:7C:6F:54:A9:7B",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "MOC-R4PAC04-SW-TORS",
+                        "port_id": "twentyfivegige 1/36",
+                        "switch_id": "3c:2c:30:44:09:02"
+                    }
+                }
+            ]
+        },
+	{
+            "name": "MOC-R4PAC04U35",
+            "properties": {
+                "capabilities": "iscsi_boot:True"
+            },
+            "resource_class": "whitebox-flax-2",
+            "driver": "ipmi",
+            "driver_info": {
+                "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+                "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+                "ipmi_username": "root",
+                "ipmi_password": "",
+                "ipmi_address": "10.2.16.180",
+                "ipmi_terminal_port": 16180
+            },
+            "ports": [
+                {
+                    "address": "40:A6:B7:C3:37:35",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "MOC-R4PAC04-SW-TORS",
+                        "port_id": "twentyfivegige 1/33",
+                        "switch_id": "3c:2c:30:44:09:02"
+                    }
+                },
+                {
+                    "address": "40:A6:B7:C3:37:34",
+                    "physical_network": "datacentre",
+                    "local_link_connection": {
+                        "switch_info": "MOC-R4PAC04-SW-TORS",
+                        "port_id": "twentyfivegige 1/34",
+                        "switch_id": "3c:2c:30:44:09:02"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/nodes/bm_inventory_r4pac04.json
+++ b/nodes/bm_inventory_r4pac04.json
@@ -53,7 +53,7 @@
             },
             "ports": [
                 {
-                    "address": "40:A6:B7:C3:37:35",
+                    "address": "40:A6:B7:C3:37:34",
                     "physical_network": "datacentre",
                     "local_link_connection": {
                         "switch_info": "MOC-R4PAC04-SW-TORS",
@@ -62,7 +62,7 @@
                     }
                 },
                 {
-                    "address": "40:A6:B7:C3:37:34",
+                    "address": "40:A6:B7:C3:37:35",
                     "physical_network": "datacentre",
                     "local_link_connection": {
                         "switch_info": "MOC-R4PAC04-SW-TORS",


### PR DESCRIPTION
These are 2 oddball nodes with no model number (custom built), hence the weird resource class. This PR also adds the TORS in that rack (which will be used for other nodes momentarily)

@tzumainn these are the UEFI nodes I was talking about, so there may be some extra steps here