### PR TITLE
Updated MACs for R8-PA-C23-U26 and U28

### DIFF
--- a/nodes/bm_inventory_r8pac23.json
+++ b/nodes/bm_inventory_r8pac23.json
@@ -44,7 +44,7 @@
       },
       "ports": [
         {
-          "address": "08:8F:C3:A5:FF:5C",
+          "address": "08:8F:C3:A2:BC:90",
           "physical_network": "datacentre",
           "local_link_connection": {
             "switch_info": "NERC-R8PAC23-SW-TORS",
@@ -98,7 +98,7 @@
       },
       "ports": [
         {
-          "address": "08:8F:C3:A6:12:EE",
+          "address": "7C:8A:E1:D1:D5:0E",
           "physical_network": "datacentre",
           "local_link_connection": {
             "switch_info": "NERC-R8PAC23-SW-TORS",


### PR DESCRIPTION
Since the board was replaced on these the MACs changed.

**NOTE: these node are not yet reachable on their BMC IPs, the dhcp needs to catch up, should happen soon.**