### PR TITLE
Added NERC Infra Routed Network

### DIFF
--- a/openstack_commands/network.sh
+++ b/openstack_commands/network.sh
@@ -49,6 +49,16 @@ openstack subnet create \
           --host-route destination=140.247.236.0/25,gateway=10.0.120.1 \
           --dhcp subnet-nese-storage
 
+# NERC 2176 routed network
+openstack network create --provider-network-type vlan --provider-segment 2076 --provider-physical-network datacentre --project nerc-admins --share nerc-infra-routed
+openstack subnet create \
+          --network nerc-infra-routed \
+          --subnet-range 10.85.0.0/22  \
+          --ip-version 4 \
+          --allocation-pool start=10.85.1.0,end=10.85.3.254 \
+          --host-route destination=10.30.9.0/24,gateway=10.85.0.1 \
+          --dhcp subnet-nerc-infra-routed
+
 # provisioning router
 openstack router create provisionrouter
 openstack router add subnet provisionrouter subnet-provisioning

--- a/openstack_commands/network.sh
+++ b/openstack_commands/network.sh
@@ -49,16 +49,6 @@ openstack subnet create \
           --host-route destination=140.247.236.0/25,gateway=10.0.120.1 \
           --dhcp subnet-nese-storage
 
-# NERC 2176 routed network
-openstack network create --provider-network-type vlan --provider-segment 2076 --provider-physical-network datacentre --project nerc-admins --share nerc-infra-routed
-openstack subnet create \
-          --network nerc-infra-routed \
-          --subnet-range 10.85.0.0/22  \
-          --ip-version 4 \
-          --allocation-pool start=10.85.1.0,end=10.85.3.254 \
-          --host-route destination=10.30.9.0/24,gateway=10.85.0.1 \
-          --dhcp subnet-nerc-infra-routed
-
 # provisioning router
 openstack router create provisionrouter
 openstack router add subnet provisionrouter subnet-provisioning

--- a/openstack_commands/owned_networks.sh
+++ b/openstack_commands/owned_networks.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # NERC 2176 routed network
-openstack network create --provider-network-type vlan --provider-segment 2076 --provider-physical-network datacentre --project nerc-admins --share nerc-infra-routed
+openstack network create --provider-network-type vlan --provider-segment 2076 --provider-physical-network datacentre --project nerc-admins nerc-infra-routed
 openstack subnet create \
           --network nerc-infra-routed \
           --subnet-range 10.85.0.0/22  \

--- a/openstack_commands/owned_networks.sh
+++ b/openstack_commands/owned_networks.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# NERC 2176 routed network
+openstack network create --provider-network-type vlan --provider-segment 2076 --provider-physical-network datacentre --project nerc-admins --share nerc-infra-routed
+openstack subnet create \
+          --network nerc-infra-routed \
+          --subnet-range 10.85.0.0/22  \
+          --ip-version 4 \
+          --allocation-pool start=10.85.1.0,end=10.85.3.254 \
+          --host-route destination=10.30.9.0/24,gateway=10.85.0.1 \
+          --dhcp subnet-nerc-infra-routed


### PR DESCRIPTION
This is for: https://github.com/nerc-project/operations/issues/726

This network should be owned by `nerc-admins`, I added the `--project` argument for that. The router is external, ESI will only provide DHCP. This network will need to be shared to other projects in ESI (as outlined in the issue) - since nerc-admins owns it I thought it may not be a great idea to add the shares in here too but I'm open to other ideas.

For the sharing - it will likely be a combination of nerc-admins members and esi admins assigning projects via sharing, though nerc-admins should always have a way to change that from their end