### PR TITLE
Fixing MOC-R8PAC23U25 A100 Node

### DIFF
--- a/nodes/bm_inventory_r8pac23.json
+++ b/nodes/bm_inventory_r8pac23.json
@@ -17,7 +17,7 @@
       },
       "ports": [
         {
-          "address": "08:8F:C3:A5:FF:B0",
+          "address": "08:8F:C3:A2:BB:6A",
           "physical_network": "datacentre",
           "local_link_connection": {
             "switch_info": "NERC-R8PAC23-SW-TORS",


### PR DESCRIPTION
MOC-R8PAC23U25 had its board swapped so the mac address of the interface needs to be updated.