### PR TITLE
Adding AMD Mi210 GPU Node

### DIFF
--- a/ansible-deployment/ironic_config/tasks/accelerators.yaml
+++ b/ansible-deployment/ironic_config/tasks/accelerators.yaml
@@ -11,3 +11,7 @@ pci_devices:
     device_id: "20b0"
     type: GPU
     device_info: NVIDIA Corporation GA100
+  - vendor_id: "1002"
+    device_id: "740f"
+    type: GPU
+    device_info: AMD Aldebaran/MI200 [Instinct MI210]

--- a/ansible-deployment/switch/tasks/switches.j2
+++ b/ansible-deployment/switch/tasks/switches.j2
@@ -176,6 +176,19 @@ mac=3c:2c:30:44:09:02
 manage_vlans=True
 ansible_connection=local
 stp_edge=True
+[ansible:MOC-R4PAC02-SW-TORS]
+ansible_connection=ansible.netcommon.network_cli
+ansible_network_os=dellemc.os9.os9
+ansible_host=10.2.17.1
+ansible_user=admin
+ansible_ssh_pass={{ ansible_sw_moc_ssh_password }}
+ansible_become_password={{ ansible_sw_moc_ssh_password }}
+ansible_become=yes
+ansible_become_method=enable
+mac=54:bf:64:b3:52:c2
+manage_vlans=True
+ansible_connection=local
+stp_edge=True
 [ansible:OCT4-SW-ESIDEV]
 ansible_connection=ansible.netcommon.network_cli
 ansible_network_os=dellemc.os9.os9

--- a/nodes/bm_inventory_r4pac02.json
+++ b/nodes/bm_inventory_r4pac02.json
@@ -1,0 +1,40 @@
+{
+  "nodes": [
+    {
+      "name": "MOC-AMDTEST1",
+      "properties": {
+        "capabilities": "boot_mode:uefi,iscsi_boot:True"
+      },
+      "resource_class": "r740xd_amdmi210",
+      "driver": "ipmi",
+      "driver_info": {
+        "deploy_kernel": "42298c88-7927-4fa5-999a-a4f03a8c3272",
+        "deploy_ramdisk": "bb5adbc2-0d7a-4993-ace4-b30a6385c9fd",
+        "ipmi_username": "root",
+        "ipmi_password": "",
+        "ipmi_address": "10.2.17.220",
+        "ipmi_terminal_port": 17220
+      },
+      "ports": [
+        {
+          "address": "B0:26:28:1A:56:DC",
+          "physical_network": "datacentre",
+          "local_link_connection": {
+            "switch_info": "MOC-R4PAC02-SW-TORS",
+            "port_id": "twentyfivegige 1/33",
+            "switch_id": "54:bf:64:b3:52:c2"
+          }
+        },
+        {
+          "address": "B0:26:28:1A:56:DD",
+          "physical_network": "datacentre",
+          "local_link_connection": {
+            "switch_info": "MOC-R4PAC02-SW-TORS",
+            "port_id": "twentyfivegige 1/34",
+            "switch_id": "54:bf:64:b3:52:c2"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Single node that is likely temporary for a few months.

I'm not sure what the device id and vendor id is. @tzumainn do you know how to find that info? Do we have to boot the node for that?