### PR TITLE
Set NeutronGlobalPhysnetMtu to 9000

### DIFF
--- a/esi-custom.yaml
+++ b/esi-custom.yaml
@@ -15,6 +15,7 @@ parameter_defaults:
   NeutronMechanismDrivers: [openvswitch, baremetal]
   NeutronNetworkVLANRanges: datacentre:351:464,datacentre:520:622,datacentre:624:630
   NeutronTypeDrivers: [local, geneve, vlan, flat, vxlan]
+  NeutronGlobalPhysnetMtu: 9000
 
   PublicVirtualFixedIPs: [{'ip_address':'129.10.5.144'}]
 


### PR DESCRIPTION
This will allow users to create neutron networks supporting
jumbo frames, useful for storage-related needs.