### PR TITLE
Added IBMScale Tenant Networks

### DIFF
--- a/openstack_commands/owned_networks.sh
+++ b/openstack_commands/owned_networks.sh
@@ -14,3 +14,40 @@ openstack network create --provider-network-type vlan --provider-segment 300 --p
 
 # IBMScale Highspeed network 2304
 openstack network create --provider-network-type vlan --provider-segment 2304 --provider-physical-network datacentre --project ibmscale ibmscale-highspeed
+
+# IBMScale Tenant Nets
+openstack network create --provider-network-type vlan --provider-segment 2305 --provider-physical-network datacentre --project ibmscale ibmscale-tenant1
+openstack subnet create \
+          --network ibmscale-tenant1 \
+          --subnet-range 10.8.0.0/18  \
+          --ip-version 4 \
+          --allocation-pool start=10.8.1.0,end=10.8.63.254 \
+          --host-route destination=10.7.0.0/20,gateway=10.8.0.1 \
+          --dhcp subnet-ibmscale-tenant1
+
+openstack network create --provider-network-type vlan --provider-segment 2306 --provider-physical-network datacentre --project ibmscale ibmscale-tenant2
+openstack subnet create \
+          --network ibmscale-tenant2 \
+          --subnet-range 10.8.64.0/18  \
+          --ip-version 4 \
+          --allocation-pool start=10.8.65.0,end=10.8.127.254 \
+          --host-route destination=10.7.0.0/20,gateway=10.8.64.1 \
+          --dhcp subnet-ibmscale-tenant2
+
+openstack network create --provider-network-type vlan --provider-segment 2307 --provider-physical-network datacentre --project ibmscale ibmscale-tenant3
+openstack subnet create \
+          --network ibmscale-tenant3 \
+          --subnet-range 10.8.128.0/18  \
+          --ip-version 4 \
+          --allocation-pool start=10.8.129.0,end=10.8.191.254 \
+          --host-route destination=10.7.0.0/20,gateway=10.8.128.1 \
+          --dhcp subnet-ibmscale-tenant3
+
+openstack network create --provider-network-type vlan --provider-segment 2308 --provider-physical-network datacentre --project ibmscale ibmscale-tenant4
+openstack subnet create \
+          --network ibmscale-tenant4 \
+          --subnet-range 10.8.192.0/18  \
+          --ip-version 4 \
+          --allocation-pool start=10.8.193.0,end=10.8.254.254 \
+          --host-route destination=10.7.0.0/20,gateway=10.8.192.1 \
+          --dhcp subnet-ibmscale-tenant4


### PR DESCRIPTION
4 separate networks that all route to the same place. I updated the switchport on the controllers to have VLANs tagged `2305-2308` but I guess interfaces need to be made on the ESI controllers to be able to serve DHCP?

Use IP addresses `10.8.X.11`, `.12`, `.13` if needed, where X is the bottom octet so for 2305 it would be 10.8.0.11, 10.8.0.12, 10.8.0.13.