### PR TITLE
Deleting IBMScale tenant subnets

### DIFF
--- a/openstack_commands/owned_networks.sh
+++ b/openstack_commands/owned_networks.sh
@@ -17,37 +17,9 @@ openstack network create --provider-network-type vlan --provider-segment 2304 --
 
 # IBMScale Tenant Nets
 openstack network create --provider-network-type vlan --provider-segment 2305 --provider-physical-network datacentre --project ibmscale ibmscale-tenant1
-openstack subnet create \
-          --network ibmscale-tenant1 \
-          --subnet-range 10.8.0.0/18  \
-          --ip-version 4 \
-          --allocation-pool start=10.8.1.0,end=10.8.63.254 \
-          --host-route destination=10.7.0.0/20,gateway=10.8.0.1 \
-          --dhcp subnet-ibmscale-tenant1
 
 openstack network create --provider-network-type vlan --provider-segment 2306 --provider-physical-network datacentre --project ibmscale ibmscale-tenant2
-openstack subnet create \
-          --network ibmscale-tenant2 \
-          --subnet-range 10.8.64.0/18  \
-          --ip-version 4 \
-          --allocation-pool start=10.8.65.0,end=10.8.127.254 \
-          --host-route destination=10.7.0.0/20,gateway=10.8.64.1 \
-          --dhcp subnet-ibmscale-tenant2
 
 openstack network create --provider-network-type vlan --provider-segment 2307 --provider-physical-network datacentre --project ibmscale ibmscale-tenant3
-openstack subnet create \
-          --network ibmscale-tenant3 \
-          --subnet-range 10.8.128.0/18  \
-          --ip-version 4 \
-          --allocation-pool start=10.8.129.0,end=10.8.191.254 \
-          --host-route destination=10.7.0.0/20,gateway=10.8.128.1 \
-          --dhcp subnet-ibmscale-tenant3
 
 openstack network create --provider-network-type vlan --provider-segment 2308 --provider-physical-network datacentre --project ibmscale ibmscale-tenant4
-openstack subnet create \
-          --network ibmscale-tenant4 \
-          --subnet-range 10.8.192.0/18  \
-          --ip-version 4 \
-          --allocation-pool start=10.8.193.0,end=10.8.254.254 \
-          --host-route destination=10.7.0.0/20,gateway=10.8.192.1 \
-          --dhcp subnet-ibmscale-tenant4


### PR DESCRIPTION
These are switching to external DHCP.

Subnets need to be deleted and the interfaces on the controllers also need to be deleted so they no longer allocated IPs on the 10.8.X subnets.